### PR TITLE
Add sqs queue in AWS for flas_app

### DIFF
--- a/terraform/sqs.tf
+++ b/terraform/sqs.tf
@@ -1,9 +1,9 @@
-# resource "aws_sqs_queue" "terraform_queue" {
-#   name                      = "terraform-example-queue"
-#   delay_seconds             = 90
-#   max_message_size          = 2048
-#   message_retention_seconds = 86400
-#   receive_wait_time_seconds = 10
-#
-#   tags = local.common_tags
-# }
+resource "aws_sqs_queue" "terraform_queue" {
+  name                      = "terraform-example-queue"
+  delay_seconds             = 90
+  max_message_size          = 2048
+  message_retention_seconds = 86400
+  receive_wait_time_seconds = 10
+
+  tags = local.common_tags
+}


### PR DESCRIPTION
With this PR we are adding an SQS queue in the `us-east-1` AWS region to be used by `flask_app` next release. 